### PR TITLE
🔧 fix(vulncheck): update Go version to 1.25.5 in workflow

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -9,5 +9,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@357ea4a5418cb457db33ccd168e28f68e075eba0
         with:
-          go-version-input: 1.25.3
+          go-version-input: 1.25.5
           go-package: ./...


### PR DESCRIPTION
Updated the Go version input in the vulncheck workflow to enhance security and compatibility with the latest dependencies.